### PR TITLE
Add automatic pg_trgm extension migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ OSCAR_PRODUCT_SEARCH_HANDLER = 'oscar_pg_search.postgres_search_handler.Postgres
 HAYSTACK_CONNECTIONS = {"default": {}}
 ```
 
-Trigram search is our search algorithm. Enable it at your database by executing the following sql:
+Trigram search is our search algorithm. A migration is included to enable it at your database. Run migrations to install it
 
 ```
-CREATE EXTENSION pg_trgm;
+python manage.py migrate django-oscar-pg-search
 ```
 
 Optional Search box

--- a/README.md
+++ b/README.md
@@ -58,10 +58,20 @@ OSCAR_PRODUCT_SEARCH_HANDLER = 'oscar_pg_search.postgres_search_handler.Postgres
 HAYSTACK_CONNECTIONS = {"default": {}}
 ```
 
-Trigram search is our search algorithm. A migration is included to enable it at your database. Run migrations to install it
+Trigram search is our search algorithm. A migration is included to enable it at your database, if it isn't already. Run migrations to install it
 
 ```
 python manage.py migrate django-oscar-pg-search
+```
+
+This ends up executing the following SQL:
+```
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
+To remove the extension, run this:
+```
+python manage.py migrate django-oscar-pg-search zero
 ```
 
 Optional Search box

--- a/src/oscar_pg_search/migrations/0001_add_trigram_extension.py
+++ b/src/oscar_pg_search/migrations/0001_add_trigram_extension.py
@@ -1,0 +1,12 @@
+from django.contrib.postgres.operations import CreateExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        CreateExtension("pg_trgm"),
+    ]


### PR DESCRIPTION
added migration, and note in readme. should be idempotent and work when extension is already enabled, including installs of previous releases.